### PR TITLE
chore: Correct next summit location in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -9,7 +9,7 @@ assignees: ovflowd, ruyadorno
 ### Proposal
 
 <!--
-Thank you! You are submitting a topic for the next Collaborator's Summit, Vancouver (CA) 2023!
+Thank you! You are submitting a topic for the next Collaborator's Summit, Bilbao (ES) 2023!
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 


### PR DESCRIPTION
The template referenced Vancouver still in one place.